### PR TITLE
Add a crosspost feature

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,8 +5,13 @@ layout: default
 
     <header class="post-header">
       <h1 class="post-title">{{ page.title }}</h1>
-      <p class="post-meta">{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
+      <p class="post-meta">{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}
+      {% if page.crosspost_site %}
+      • Crossposted from <a href="{{ page.crosspost_url }}">{{ page.crosspost_site }}</a>.
+      {% endif %}
+      </p>
     </header>
+
     {{ content }}
 
 </article>

--- a/_posts/2014-12-5-archlinux-install.markdown
+++ b/_posts/2014-12-5-archlinux-install.markdown
@@ -2,6 +2,9 @@
 layout: post
 title: My notes on installing Arch Linux on my Lenovo T420s
 tags: linux
+author: Antoine
+crosspost_site: Antoine's blog
+crosspost_url: http://antoinealb.net/2014/12/05/archlinux-install.html
 ---
 I recently decided I wanted to reinstall my Arch Linux system.
 I have been running Arch on my Lenovo T420s for a few years now, and it has been working flawlessly.


### PR DESCRIPTION
Since I and some other team members have their own blogs where
they sometimes post stuff about the club I thought it would be nice to
have an option to repost something but still attribute the article to
the original place, where it might have been extended, corrected, etc.

To do this I added two optionals attributes to the posts:
- crosspost_site: Human readable title for the original page's website.
  e.g "Antoine's website" or "Wise Robotics Engineering blog".
- crosspost_url: Link to the original post if possible and to the
  website if not.

What do you think ?

@nuft @SyrianSpock 
