### PR TITLE
Disable Github Flavored Markdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,8 +20,6 @@ exclude: [.bundle, bin, vendor, Gemfile, Gemfile.lock, Rakefile, s3_website.yml,
 
 # Build settings
 markdown: kramdown
-kramdown:
-  input: GFM
 highlighter: pygments
 
 destination: _site


### PR DESCRIPTION
GFM is causing issues with the line breaks, replacing every new line
with an HTML </br>, which causes the text to look ugly.

There is a solution to this problem (see
https://github.com/gettalong/kramdown/pull/83) but I could not get it to
work on my machine.

As GFM doesn't bring us significant advantages, and given that
@syrianspock and myself use standard Jekyll markdown for our respective
blogs it makes more sense to disable GFM for now.

With this patch:
<img width="1237" alt="screen shot 2015-09-11 at 08 49 02" src="https://cloud.githubusercontent.com/assets/2419961/9808810/006af8a4-5863-11e5-816f-41ff1aa7ce17.png">

Before:
<img width="1008" alt="screen shot 2015-09-11 at 08 49 35" src="https://cloud.githubusercontent.com/assets/2419961/9808812/0593fc7c-5863-11e5-8637-d9fd613b9796.png">

@SyrianSpock Ok for you ?
