### PR TITLE
add landminefree to rankings

### DIFF
--- a/_data/records.yaml
+++ b/_data/records.yaml
@@ -190,3 +190,10 @@
   robots: Hansel & Gretel
   round: Group Stage
   rank: 9th
+
+- year: 2018
+  theme: Landmine detection
+  competition: Landminefree
+  city: Madrid (ES)
+  robots: Sisyphos
+  distinction: Academia Best Design

--- a/rankings.html
+++ b/rankings.html
@@ -25,7 +25,7 @@ title: Rankings
 }
 </style>
 
-{% assign competitions = "SwissEurobot,Eurobot,Belgium Eurobot,Cup of Île-de-France" | split: ',' %}
+{% assign competitions = "SwissEurobot,Eurobot,Belgium Eurobot,Cup of Île-de-France,Landminefree" | split: ',' %}
 {% for competition in competitions %}
 <h2><b>{{competition}}</b></h2>
 <table id="customers">


### PR DESCRIPTION
This PR add landminefree record on the ranking page:

![rankings-add-landminefree](https://user-images.githubusercontent.com/38395898/52049843-17981e00-254f-11e9-81a4-d0d6d2d3ffaa.png)

If we do more side competition in the future, we can rename "Landminefree" to "Other competition" and "theme" to "competition".


